### PR TITLE
Add faceting using keywords

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/setup-node@v1
         name: Use Node.js
         with:
-          node-version: 13.x
+          # Update once parcel updates its babel dependency?
+          # https://github.com/parcel-bundler/parcel/issues/4276
+          node-version: 13.9.0
 
       - run: npm ci
         name: Install

--- a/css/index.css
+++ b/css/index.css
@@ -127,6 +127,16 @@ img.search-item__thumbnail {
   font-size: inherit;
 }
 
+/* If there are items in the refinement list, make sure we add a bottom margin
+ * otherwise there shouldn't be any extra margin.
+ */
+.ais-CurrentRefinements-list li:last-child {
+  margin-bottom: 1em;
+}
+
+/* Ensure that the first header doesn't have top margin so it lines up cleanly
+ * with the search bar
+ */
 .search-panel__facets > h2:first-of-type {
-  margin-top: 0;
+  margin-top: 0em;
 }

--- a/css/index.css
+++ b/css/index.css
@@ -140,3 +140,13 @@ img.search-item__thumbnail {
 .search-panel__facets > h2:first-of-type {
   margin-top: 0em;
 }
+
+/* Hide the count associated with refinements because counts don't match up
+ * well with the idea of breaking a document down into multiple records.
+ *
+ * It might be better to eventually customize the template for refinement
+ * labels so this never appears.
+ */
+.ais-RefinementList-count {
+  visibility: hidden;
+}

--- a/css/index.css
+++ b/css/index.css
@@ -31,6 +31,28 @@ body {
   padding: 1em;
 }
 
+/* Container for the search UI */
+.search-panel {
+  display: grid;
+  grid-template-columns: 15em 1fr;
+  grid-template-rows: auto;
+  grid-column-gap: 2em;
+  grid-template-areas: 'facets results';
+}
+
+/* Container nominally on the left side that contains facets
+ */
+.search-panel__facets {
+  grid-area: facets;
+}
+
+/* Container nominally on the right side that contains the search bar followed
+ * by the results.
+ */
+.search-panel__results {
+  grid-area: results;
+}
+
 /* Container for both the searchbox and powered-by widgets. */
 .search-bar {
   display: flex;
@@ -103,4 +125,8 @@ img.search-item__thumbnail {
 .ais-Highlight-highlighted {
   color: inherit;
   font-size: inherit;
+}
+
+.search-panel__facets > h2:first-of-type {
+  margin-top: 0;
 }

--- a/index.html
+++ b/index.html
@@ -17,6 +17,13 @@
 
   <div class="container">
     <div class="search-panel">
+      <div class="search-panel__facets">
+        <div id="current-refinements"></div>
+
+        <h2>Keywords</h2>
+        <div id="keyword-facet"></div>
+      </div>
+
       <div class="search-panel__results">
         <div class="search-bar">
           <div id="searchbox"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1026,13 +1026,21 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.3.tgz",
-      "integrity": "sha512-lrIU4aVbmlM/wQPzhEvzvNJskKyYptuXb0fGC0lTQTupTOYtR2Vqbu6/jf8vTr4M8Wt1nIzxVrSvPI5qESa/xA==",
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.8.7.tgz",
+      "integrity": "sha512-sc7A+H4I8kTd7S61dgB9RomXu/C+F4IrRr4Ytze4dnfx7AXEpCrejSNpjx7vq6y/Bak9S6Kbk65a/WgMLtg43Q==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz",
+          "integrity": "sha512-plpwicqEzfEyTQohIKktWigcLzmNStMGwbOUbykx51/29Z3JOGYldaaNGK7ngNXV+UcoqvIMmloZ48Sr74sd+g==",
+          "dev": true
+        }
       }
     },
     "@babel/template": {
@@ -1170,9 +1178,9 @@
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+      "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
       "dev": true
     },
     "acorn-globals": {
@@ -1516,14 +1524,10 @@
       "dev": true
     },
     "axobject-query": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
-      "integrity": "sha512-lF98xa/yvy6j3fBHAgQXIYl+J4eZadOSqsPojemUqClzNbBV38wWGpUbQbVEyf4eUF5yF7eHmGgGA2JiHyjeqw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.7.4",
-        "@babel/runtime-corejs3": "^7.7.4"
-      }
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.2.tgz",
+      "integrity": "sha512-ICt34ZmrVt8UQnvPl6TVyDTkmhXmAyAT4Jh5ugfGUX4MOrZ+U/ZY6/sdylRw3qGNr9Ub5AJsaHeDMzNLehRdOQ==",
+      "dev": true
     },
     "babel-eslint": {
       "version": "9.0.0",
@@ -3414,9 +3418,9 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz",
-      "integrity": "sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
+      "integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -3427,8 +3431,10 @@
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.14.2",
-        "string.prototype.matchall": "^4.0.2"
+        "resolve": "^1.15.1",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.2",
+        "xregexp": "^4.3.0"
       },
       "dependencies": {
         "doctrine": {
@@ -3439,6 +3445,21 @@
           "requires": {
             "esutils": "^2.0.2"
           }
+        },
+        "resolve": {
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -4729,9 +4750,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.7.tgz",
-      "integrity": "sha512-ChkjQtKJ3GI6SsI4O5jwr8q8EPrWCnxuc4Tbx+vRI5x6mDOpjKKltNo1lRlszw3xwgTOSns1ZRBiMmmwpcvLxg==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
       "dev": true
     },
     "hsl-regex": {
@@ -5002,9 +5023,9 @@
       "integrity": "sha512-CaOdFWCpHOWGAkJRpwC4+8ROU3Upp3xrUuc0Mg92UucJ84MWMJWkVZDDyRwubgJe4HXQM2rV6b+bJaDeeZGunw=="
     },
     "instantsearch.js": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.3.0.tgz",
-      "integrity": "sha512-PLGxv71P618x/tK/V4rSQ/x91+8I+A4oNuhy9INyeHbh09aRvWDBJogLlSpcS0zBGd2Fu1o3k8ZnFlZOIotfYg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/instantsearch.js/-/instantsearch.js-4.3.1.tgz",
+      "integrity": "sha512-FPPUkl9aR/F1IykS++H6JKvTz4n3W4PmAuuStNrstW8ugchID9guQSIqgwTL6BMefUuhVIgteLrTbi8IzBRkCw==",
       "requires": {
         "algoliasearch-helper": "^3.1.1",
         "classnames": "^2.2.5",
@@ -7009,9 +7030,9 @@
       "dev": true
     },
     "preact": {
-      "version": "10.3.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.3.2.tgz",
-      "integrity": "sha512-yIx4i7gp45enhzX4SLkvvR20UZ+YOUbMdj2KEscU/dC70MHv/L6dpTcsP+4sXrU9SRbA3GjJQQCPfFa5sE17dQ=="
+      "version": "10.3.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.3.3.tgz",
+      "integrity": "sha512-8EWUuHuLhX48uK0acnnXwBL/ZyrgeadnyhxG6hFI85BhwmquyGwWzfj2SylCNdEyltkdgbY3FZzQOM2mG1leAg=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -8959,6 +8980,15 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "not dead"
   ],
   "devDependencies": {
-    "acorn": "^7.1.0",
+    "acorn": "^7.1.1",
     "autoprefixer": "^9.7.4",
     "babel-eslint": "^9.0.0",
     "css-loader": "^3.4.2",
@@ -52,7 +52,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.2",
-    "eslint-plugin-react": "^7.18.3",
+    "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^1.7.0",
     "parcel-bundler": "^1.12.4",
     "postcss-normalize": "^8.0.1",
@@ -62,7 +62,7 @@
   "dependencies": {
     "algoliasearch": "^4.0.3",
     "instantsearch.css": "^7.4.2",
-    "instantsearch.js": "^4.3.0",
+    "instantsearch.js": "^4.3.1",
     "normalize": "^0.3.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "description": "This repository is a demonstration of a documentation search service for the [Astropy Project](https://www.astropy.org). The site itself is built around [Algolia](https://www.algolia.com). Records for the Algolia database are curated and formatted by the [astropy-librarian](https://github.com/jonathansick/astropy-librarian) app. Ultimately this search functionality will be built into the [learn.astropy.org](https://learn.astropy.org) site; in the meantime this stripped-down site lets us explore the interplay between front-end search experience and back-end data preparation.",
-  "main": "index.js",
+  "browser": "src/index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "lint": "eslint .",

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,7 @@ search.addWidgets([
   refinementList({
     container: '#keyword-facet',
     attribute: 'keywords',
+    sortBy: ['isRefined', 'name:asc'],
   }),
 ]);
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,12 @@
 import algoliasearch from 'algoliasearch/lite';
 import instantsearch from 'instantsearch.js';
-import { searchBox, hits, poweredBy } from 'instantsearch.js/es/widgets';
+import {
+  searchBox,
+  hits,
+  poweredBy,
+  currentRefinements,
+  refinementList,
+} from 'instantsearch.js/es/widgets';
 
 import { emptyTemplate, itemTemplate } from './templates';
 
@@ -30,6 +36,15 @@ search.addWidgets([
       empty: emptyTemplate,
       item: itemTemplate,
     },
+  }),
+
+  currentRefinements({
+    container: '#current-refinements',
+  }),
+
+  refinementList({
+    container: '#keyword-facet',
+    attribute: 'keywords',
   }),
 ]);
 


### PR DESCRIPTION
This PR demonstrates faceting in the search UI. So far we're faceting using `keywords` attribute. 
This faceting UI includes its own search box for keywords since the number of keywords is larger than the number that can be reasonably displayed.

In addition to the facet widget, the UI also contains a current-refinements widget to let users easily reset whatever refinements they've added.

For this to work, we've identified `keywords` as an "attribute for faceting."

UI-wise, we've added a grid layout to control the search panel. There's a new grid area on the left where we've put our refinements list.

<img width="1124" alt="Screen Shot 2020-03-09 at 9 52 21 AM" src="https://user-images.githubusercontent.com/349384/76219232-e5de9580-61eb-11ea-9054-b43ef7388cbc.png">

