### PR TITLE
Support displaying the 4 keyword types

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -127,11 +127,10 @@ img.search-item__thumbnail {
   font-size: inherit;
 }
 
-/* If there are items in the refinement list, make sure we add a bottom margin
- * otherwise there shouldn't be any extra margin.
- */
-.ais-CurrentRefinements-list li:last-child {
-  margin-bottom: 1em;
+/* div for the currentRefinements widget */
+.ais-CurrentRefinements {
+  margin-top: -1em; /* eat into bottom margin of .search-bar */
+  margin-bottom: 2em;
 }
 
 /* Ensure that the first header doesn't have top margin so it lines up cleanly

--- a/css/index.css
+++ b/css/index.css
@@ -140,13 +140,3 @@ img.search-item__thumbnail {
 .search-panel__facets > h2:first-of-type {
   margin-top: 0em;
 }
-
-/* Hide the count associated with refinements because counts don't match up
- * well with the idea of breaking a document down into multiple records.
- *
- * It might be better to eventually customize the template for refinement
- * labels so this never appears.
- */
-.ais-RefinementList-count {
-  visibility: hidden;
-}

--- a/index.html
+++ b/index.html
@@ -20,8 +20,17 @@
       <div class="search-panel__facets">
         <div id="current-refinements"></div>
 
-        <h2>Keywords</h2>
-        <div id="keyword-facet"></div>
+        <h2>Astropy packages</h2>
+        <div id="astropy-keywords-facet"></div>
+
+        <h2>Python packages</h2>
+        <div id="python-keywords-facet"></div>
+
+        <h2>Tasks</h2>
+        <div id="task-keywords-facet"></div>
+
+        <h2>Science areas</h2>
+        <div id="science-keywords-facet"></div>
       </div>
 
       <div class="search-panel__results">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,6 @@
   <div class="container">
     <div class="search-panel">
       <div class="search-panel__facets">
-        <div id="current-refinements"></div>
 
         <h2>Astropy packages</h2>
         <div id="astropy-keywords-facet"></div>
@@ -38,6 +37,9 @@
           <div id="searchbox"></div>
           <div id="powered-by"></div>
         </div>
+
+        <div id="current-refinements"></div>
+
         <div id="hits"></div>
       </div>
 

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,14 @@ const search = instantsearch({
   searchClient,
 });
 
+// Map record field names to readable labels for the currentRefinements widget
+const refinementLabelMap = {
+  astropy_package_keywords: 'Astropy package',
+  python_package_keywords: 'Python package',
+  task_keywords: 'Task',
+  science_keywords: 'Science area',
+};
+
 search.addWidgets([
   poweredBy({
     container: '#powered-by',
@@ -44,6 +52,13 @@ search.addWidgets([
 
   currentRefinements({
     container: '#current-refinements',
+    transformItems(items) {
+      // replace the label (the record field by default) with a readable label
+      return items.map(item => ({
+        ...item,
+        label: refinementLabelMap[item.label],
+      }));
+    },
   }),
 
   refinementList({

--- a/src/index.js
+++ b/src/index.js
@@ -43,11 +43,47 @@ search.addWidgets([
   }),
 
   refinementList({
-    container: '#keyword-facet',
-    attribute: 'keywords',
+    container: '#astropy-keywords-facet',
+    attribute: 'astropy_package_keywords',
     sortBy: ['isRefined', 'name:asc'],
     searchable: true,
-    searchablePlaceholder: 'Search keywords',
+    searchablePlaceholder: 'Search packages',
+    searchableIsAlwaysActive: false, // only add search if "showMore" also visible
+    showMore: true,
+    limit: 20,
+    showMoreLimit: 500,
+  }),
+
+  refinementList({
+    container: '#python-keywords-facet',
+    attribute: 'python_package_keywords',
+    sortBy: ['isRefined', 'name:asc'],
+    searchable: true,
+    searchablePlaceholder: 'Search packages',
+    searchableIsAlwaysActive: false, // only add search if "showMore" also visible
+    showMore: true,
+    limit: 20,
+    showMoreLimit: 500,
+  }),
+
+  refinementList({
+    container: '#task-keywords-facet',
+    attribute: 'task_keywords',
+    sortBy: ['isRefined', 'name:asc'],
+    searchable: true,
+    searchablePlaceholder: 'Search tasks',
+    searchableIsAlwaysActive: false, // only add search if "showMore" also visible
+    showMore: true,
+    limit: 20,
+    showMoreLimit: 500,
+  }),
+
+  refinementList({
+    container: '#science-keywords-facet',
+    attribute: 'science_keywords',
+    sortBy: ['isRefined', 'name:asc'],
+    searchable: true,
+    searchablePlaceholder: 'Search science areas',
     searchableIsAlwaysActive: false, // only add search if "showMore" also visible
     showMore: true,
     limit: 20,

--- a/src/index.js
+++ b/src/index.js
@@ -54,8 +54,7 @@ search.addWidgets([
     searchablePlaceholder: 'Search packages',
     searchableIsAlwaysActive: false, // only add search if "showMore" also visible
     showMore: true,
-    limit: 20,
-    showMoreLimit: 500,
+    limit: 15,
     templates: {
       item: refinementListItemTemplate,
     },
@@ -69,8 +68,7 @@ search.addWidgets([
     searchablePlaceholder: 'Search packages',
     searchableIsAlwaysActive: false, // only add search if "showMore" also visible
     showMore: true,
-    limit: 20,
-    showMoreLimit: 500,
+    limit: 15,
     templates: {
       item: refinementListItemTemplate,
     },
@@ -84,8 +82,7 @@ search.addWidgets([
     searchablePlaceholder: 'Search tasks',
     searchableIsAlwaysActive: false, // only add search if "showMore" also visible
     showMore: true,
-    limit: 20,
-    showMoreLimit: 500,
+    limit: 15,
     templates: {
       item: refinementListItemTemplate,
     },
@@ -99,8 +96,7 @@ search.addWidgets([
     searchablePlaceholder: 'Search science areas',
     searchableIsAlwaysActive: false, // only add search if "showMore" also visible
     showMore: true,
-    limit: 20,
-    showMoreLimit: 500,
+    limit: 15,
     templates: {
       item: refinementListItemTemplate,
     },

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,11 @@ import {
   refinementList,
 } from 'instantsearch.js/es/widgets';
 
-import { emptyTemplate, itemTemplate } from './templates';
+import {
+  emptyTemplate,
+  itemTemplate,
+  refinementListItemTemplate,
+} from './templates';
 
 // This is the Search-only API key
 const searchClient = algoliasearch(
@@ -52,6 +56,9 @@ search.addWidgets([
     showMore: true,
     limit: 20,
     showMoreLimit: 500,
+    templates: {
+      item: refinementListItemTemplate,
+    },
   }),
 
   refinementList({
@@ -64,6 +71,9 @@ search.addWidgets([
     showMore: true,
     limit: 20,
     showMoreLimit: 500,
+    templates: {
+      item: refinementListItemTemplate,
+    },
   }),
 
   refinementList({
@@ -76,6 +86,9 @@ search.addWidgets([
     showMore: true,
     limit: 20,
     showMoreLimit: 500,
+    templates: {
+      item: refinementListItemTemplate,
+    },
   }),
 
   refinementList({
@@ -88,6 +101,9 @@ search.addWidgets([
     showMore: true,
     limit: 20,
     showMoreLimit: 500,
+    templates: {
+      item: refinementListItemTemplate,
+    },
   }),
 ]);
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -27,3 +27,12 @@ export const itemTemplate = `
   </div>
 </article>
 `;
+
+// Refinement item template
+// https://www.algolia.com/doc/api-reference/widgets/refinement-list/js/#templates
+export const refinementListItemTemplate = `
+<label class="ais-RefinementList-label">
+  <input class="ais-RefinementList-checkbox" type="checkbox" value="{{ label }}" {{#isRefined}}checked=""{{/isRefined}}>
+  <span class="ais-RefinementList-labelText" style="{{#isRefined}}font-weight: bold{{/isRefined}}">{{ label }}</span>
+</label>
+`;


### PR DESCRIPTION
This PR breaks down the former "Keywords" keyword listing into separate listings for the four keyword types:

- Astropy packages
- Python packages
- Tasks
- Science areas

Additionally, it solves some UI problems:

- Adds a custom template for refinement list items that doesn't include the count (which is obviously useful in this context).
- Moves current refinements to below the search box for more horizontal space.
- Adds human-readable labels for the keyword categories in current refinements.

<img width="1122" alt="Screen Shot 2020-03-15 at 5 18 54 PM" src="https://user-images.githubusercontent.com/349384/76710839-1721fe80-66e1-11ea-8f71-92b2bcf44514.png">
